### PR TITLE
add a shadow of the target in the output box

### DIFF
--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -143,6 +143,11 @@ function loadProblem() {
         throwOnError: false,
         displayMode: true
     });
+    // load problem body
+    katex.render(target.latex, $("#shadow-target")[0], {
+        throwOnError: false,
+        displayMode: true
+    });
 
     oldVal = "";
 };

--- a/public/assets/style/style.css
+++ b/public/assets/style/style.css
@@ -187,7 +187,7 @@ main {
 #shadow-target {
   opacity: 1;
   z-index: 0;
-  color: yellow;
+  color: #ccc;
 }
 .latex.out {
   position: absolute;

--- a/public/assets/style/style.css
+++ b/public/assets/style/style.css
@@ -180,3 +180,21 @@ main {
 #problem-title {
 	font-weight: bold;
 }
+
+.out-container {
+  position: relative;
+}
+#shadow-target {
+  opacity: 1;
+  z-index: 0;
+  color: yellow;
+}
+.latex.out {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+}
+.latex {
+	box-sizing: border-box;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -99,8 +99,14 @@
 
             <p> This is what your output looks like: </p>
 
-            <div class="latex">
-              <div id="out"></div>
+            <div class="out-container">
+                <div class="latex">
+                  <div id="shadow-target"></div>
+                </div>
+
+                <div class="latex out">
+                  <div id="out"></div>
+                </div>
             </div>
 
             <br>


### PR DESCRIPTION
It's hard to spot when a tiny error such as spacing means your output
isn't the same as the target.

This commit adds a faded rendering of the target in the output box, so
you can spot misaligned bits.