### PR TITLE
Show points for skipped problems

### DIFF
--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -110,8 +110,9 @@ function endGame() {
     skippedProblems.forEach(idx => {
       let target = problems[problemsOrder[idx % problems.length]];
       let targetId = 'skipTarget' + idx;
+      let skippedPoints = pluralize`(${problemScore(target)} ${"point"})`;
       let skippedProblemsHtml = `
-        <p class="problem-header"><span class="title">${target.title}</span></p>
+        <p class="problem-header"><span class="title">${target.title}</span>&nbsp;<span>${skippedPoints}</span></p>
         <div class="latex">
           <div id="${targetId}"></div>
         </div>

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -22,6 +22,10 @@ function mobileCheck() {
   return check;
 };
 
+function pluralize(strs, n, singular) {
+    return `${strs[0]}${n}${strs[1]}${singular + (n==1 ? "" : "s")}${strs[2]}`
+}
+
 function problemScore(problem) {
     return Math.ceil(problem.latex.length / 10.0);
 }
@@ -97,9 +101,9 @@ function endGame() {
     $("#game-window").hide();
     $("#ending-window").show();
     displayLaTeXInBody();
-
-    let problemsText = numCorrect + ((numCorrect == 1) ? " problem" : " problems");
-    let endingText = "You finished " + problemsText + " for a total score of " + currentScore;
+    
+    let problemsText = pluralize`${numCorrect} ${"problem"}`;
+    let endingText = `You finished ${problemsText} for a total score of ${currentScore}`;
     $("#ending-text").text(endingText);
     $("#ending-text").append("<a style='text-decoration: none;' href='https://www.reddit.com/r/unexpectedfactorial/'>!</a>");
 
@@ -190,10 +194,10 @@ function loadProblem() {
     problemNumber += 1;
 
     // load problem text
-    let problemText = "Problem " + problemNumber + ": " + target.title;
+    let problemText = `Problem ${problemNumber}: ${target.title}`;
     $("#problem-title").text(problemText);
     problemPoints = problemScore(target);
-    let pointsText = "(" + problemPoints + ((problemPoints == 1) ? " point)" : " points)");
+    let pointsText = pluralize`(${problemPoints} ${"point"})`;
     $("#problem-points").text(pointsText);
 
     displayLaTeXInBody();

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -22,6 +22,10 @@ function mobileCheck() {
   return check;
 };
 
+function problemScore(problem) {
+    return Math.ceil(problem.latex.length / 10.0);
+}
+
 function shuffleArray(array) {
     for (let i = array.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
@@ -188,7 +192,7 @@ function loadProblem() {
     // load problem text
     let problemText = "Problem " + problemNumber + ": " + target.title;
     $("#problem-title").text(problemText);
-    problemPoints = Math.ceil(target.latex.length / 10.0);
+    problemPoints = problemScore(target);
     let pointsText = "(" + problemPoints + ((problemPoints == 1) ? " point)" : " points)");
     $("#problem-points").text(pointsText);
 


### PR DESCRIPTION
Show points for the skipped problems on the end screen, so users can see how much a problem they skipped was worth. 

Since this would involve computing the score of a problem in two different places, that calculation was factored out into a problemScore function.

I also factored out pluralization code into the pluralize function which is used as a tagged template.