### PR TITLE
Change the "timer" in Zen Mode to count up from 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ node_modules/
 
 # dotenv environment variables file
 .env
+
+# Automatically generated on Mac machines when opening the directory up in finder
+.DS_Store

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -46,8 +46,12 @@ function displayTime(secs) {
     $("#timer").text(displayText);
 }
 
-function displayInfiniteTime() {
-    katex.render(`\\infty`, $("#timer")[0]);
+function infiniteTimer() {
+    secondsElapsed = 0;
+    gameTimer = setInterval(function() {
+        secondsElapsed++;
+        displayTime(secondsElapsed);
+    }, 1000);
 }
 
 function startTimer(onTimeoutFunc) {
@@ -161,8 +165,11 @@ function startGame(useTimer) {
             endGame();
         });
     } else {
-        displayInfiniteTime();
+        displayTime(0);
+
+        // Reset and start the timer
         loadProblem();
+        infiniteTimer();
     }
 }
 


### PR DESCRIPTION
I spent a long time in zen mode (doing over 100 questions), and wanted to see how much time I had spent, but I only found the infinity sign for a timer. 

I'd rather the timer actually count up so I can see how much of my life I have wasted typing LaTeX equations

I also modified the `.gitignore` to include `.DS_Store` files, which are files automatically generated on Macs when opening up finder (they are used to determine the layouts of the files and folders)