### PR TITLE
Vim Mode Support

### DIFF
--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -17,9 +17,9 @@ let skippedProblems = [];
 let showSkipped = false;
 
 function mobileCheck() {
-  var check = false;
-  (function(a){if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4))) check = true;})(navigator.userAgent||navigator.vendor||window.opera);
-  return check;
+    var check = false;
+    (function (a) { if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))) check = true; })(navigator.userAgent || navigator.vendor || window.opera);
+    return check;
 };
 
 function shuffleArray(array) {
@@ -52,7 +52,7 @@ function displayInfiniteTime() {
 
 function startTimer(onTimeoutFunc) {
     secondsRemaining = TIMEOUT_SECONDS;
-    gameTimer = setInterval(function() {
+    gameTimer = setInterval(function () {
         secondsRemaining--;
         displayTime(secondsRemaining);
         if (secondsRemaining == 0) {
@@ -63,9 +63,9 @@ function startTimer(onTimeoutFunc) {
 }
 
 function toggleShowSkipped() {
-  $("#skipped-problems").toggle();
-  showSkipped = !showSkipped;
-  $("#show-skipped-button").text(showSkipped ? "Hide Skipped" : "Show Skipped");
+    $("#skipped-problems").toggle();
+    showSkipped = !showSkipped;
+    $("#show-skipped-button").text(showSkipped ? "Hide Skipped" : "Show Skipped");
 }
 
 function showIntro() {
@@ -74,13 +74,13 @@ function showIntro() {
     $("#intro-window").show();
     $("#score-submission").show();
 
-    let introText =  "This is a game to test your \\(\\LaTeX\\) skills. <br/> <br/>" +
-                     " Type as many formulas as you can in " + TIMEOUT_STRING + " (timed game), or play an untimed game (zen mode)!";
+    let introText = "This is a game to test your \\(\\LaTeX\\) skills. <br/> <br/>" +
+        " Type as many formulas as you can in " + TIMEOUT_STRING + " (timed game), or play an untimed game (zen mode)!";
     $("#intro-text").html(introText);
 
     if (mobileCheck()) {
-      $("#hint-list").prepend("<li><span style=\"color:red\"><b>Consider switching to a desktop browser</b></span></li>")
-      mobile = true;
+        $("#hint-list").prepend("<li><span style=\"color:red\"><b>Consider switching to a desktop browser</b></span></li>")
+        mobile = true;
     }
 
     displayLaTeXInBody();
@@ -98,14 +98,14 @@ function endGame() {
     let problemsText = numCorrect + ((numCorrect == 1) ? " problem" : " problems");
     let endingText = "You finished " + problemsText + " for a total score of " + currentScore;
     $("#ending-text").text(endingText);
-    
+
     // Load initial leaderboard
     loadLeaderboard('today');
-    
+
     skippedProblems.forEach(idx => {
-      let target = problems[problemsOrder[idx % problems.length]];
-      let targetId = 'skipTarget' + idx;
-      let skippedProblemsHtml = `
+        let target = problems[problemsOrder[idx % problems.length]];
+        let targetId = 'skipTarget' + idx;
+        let skippedProblemsHtml = `
         <p class="problem-header"><span class="title">${target.title}</span></p>
         <div class="latex">
           <div id="${targetId}"></div>
@@ -127,11 +127,11 @@ function endGame() {
     $("#show-skipped-button").text("Show Skipped");
     showSkipped = false;
     if (skippedProblems.length > 0) {
-      $("#show-skipped-message").show();
-      $("#show-skipped-button").show();
+        $("#show-skipped-message").show();
+        $("#show-skipped-button").show();
     } else {
-      $("#show-skipped-message").hide();
-      $("#show-skipped-button").hide();
+        $("#show-skipped-message").hide();
+        $("#show-skipped-button").hide();
     }
 }
 
@@ -160,7 +160,7 @@ function startGame(useTimer) {
 
         // Reset and start the timer
         loadProblem();
-        startTimer(function() {
+        startTimer(function () {
             endGame();
         });
     } else {
@@ -172,19 +172,20 @@ function startGame(useTimer) {
 function loadProblem() {
     // clear current work
     $('#out').empty();
-    $('#user-input').val('');
 
     // reset styling
     $('#out').parent().removeClass("correct");
-    $('#user-input').prop("disabled", false);
+    oldVal = "";
+    editor.setValue('');
+    editor.setOption('readOnly', false);
     if (!mobile) {
-      $('#user-input').focus();
+        editor.focus();
     }
 
     // load problem
     let target = problems[problemsOrder[problemNumber % problems.length]];
     if (debug) {
-      target = problems[problemNumber + 179];
+        target = problems[problemNumber + 179];
     }
     problemNumber += 1;
 
@@ -208,18 +209,17 @@ function loadProblem() {
         displayMode: true
     });
 
-    oldVal = "";
 };
 
 function normalize(input) {
-  normalizations.forEach(
-    rule => input = input.replace(rule["rule"], rule["replacement"])
-  );
-  return input;
+    normalizations.forEach(
+        rule => input = input.replace(rule["rule"], rule["replacement"])
+    );
+    return input;
 }
 
 function validateProblem() {
-    let currentVal = normalize($("#user-input").val());
+    let currentVal = normalize(editor.getValue());
     if (currentVal == oldVal) {
         return; // check to prevent multiple simultaneous triggers
     }
@@ -232,8 +232,8 @@ function validateProblem() {
     });
 
     if (currentVal == '') {
-      // Defensively return if the input is empty.
-      return;
+        // Defensively return if the input is empty.
+        return;
     }
 
 
@@ -250,16 +250,16 @@ function validateProblem() {
         let curTarget = $('#problem-title').text();
         html2canvas($('#out')[0], {}).then(function (outCanvas) {
             if (outCanvas.width != width || outCanvas.height != height) {
-              console.log("doesn't match");
-              return;
+                console.log("doesn't match");
+                return;
             }
             let outData = outCanvas.getContext("2d").getImageData(0, 0, width, height);
-            let diff = pixelmatch(targetData.data, outData.data, undefined, width, height, {threshold: 0.1});
+            let diff = pixelmatch(targetData.data, outData.data, undefined, width, height, { threshold: 0.1 });
             let result = "";
             console.log("diff is " + diff)
             if (diff == 0) {
                 if (lastTarget == curTarget) {
-                  return;
+                    return;
                 }
                 lastTarget = curTarget;
                 currentScore += problemPoints;
@@ -267,7 +267,7 @@ function validateProblem() {
 
                 // Styling changes
                 $('#out').parent().addClass("correct");
-                $('#user-input').prop("disabled", true);
+                editor.setOption('readOnly', true);
                 $("#score").text(currentScore);
 
                 // Load new problem
@@ -304,10 +304,10 @@ async function submitScore(name, score) {
 async function loadLeaderboard(timeRange) {
     const leaderboardList = $("#leaderboard-list");
     leaderboardList.empty();
-    
+
     try {
         let query = db.collection('leaderboard');
-        
+
         // Add time constraints based on selected range
         const now = new Date();
         if (timeRange === 'today') {
@@ -317,14 +317,14 @@ async function loadLeaderboard(timeRange) {
             const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
             query = query.where('timestamp', '>=', startOfMonth);
         }
-        
+
         const snapshot = await query.orderBy('score', 'desc').limit(10).get();
-        
+
         if (snapshot.empty) {
             leaderboardList.append('<p>No scores yet!</p>');
             return;
         }
-        
+
         let rank = 1;
         snapshot.forEach((doc) => {
             const data = doc.data();
@@ -344,55 +344,99 @@ async function loadLeaderboard(timeRange) {
     }
 }
 
+let editor = 0;
+
 // Start by showing the intro.
-$(document).ready(function() {
+$(document).ready(function () {
+    // Initialize CodeMirror editor
+    let textarea = document.getElementById("user-input");
+    textarea.removeAttribute("id");
+    editor = CodeMirror.fromTextArea(textarea, {
+        mode: "stex",
+        keyMap: "default"
+    });
+    editor.getWrapperElement().classList.add("latex-source");
+    oldVal = "";
+    editor.on("change", function () {
+        validateProblem();
+    });
+
     // Handlers
-    $("#start-button-timed").click(function() {
+    $("#start-button-timed").click(function () {
         startGame(true);
     });
 
-    $("#start-button-untimed").click(function() {
+    $("#start-button-untimed").click(function () {
         startGame(false);
     });
 
-    $("#reset-button-timed").click(function() {
+    $("#reset-button-timed").click(function () {
         startGame(true);
     });
 
-    $("#reset-button-untimed").click(function() {
+    $("#reset-button-untimed").click(function () {
         startGame(false);
     });
 
-    $("#skip-button").click(function() {
+    $("#skip-button").click(function () {
         skippedProblems.push(problemNumber - 1);
         loadProblem();
     });
+    $("#vim-checkbox").change(function () {
+        const isVimEnabled = $(this).is(":checked");
+    
+        if (isVimEnabled) {
+            editor.setOption("keyMap", "vim");
+            // Add a visual indicator so the user knows they are in a modal editor
+            editor.getWrapperElement().classList.add("vim-mode");
+        } else {
+            editor.setOption("keyMap", "default");
+            editor.getWrapperElement().classList.remove("vim-mode");
+        }
+    
+        // Always focus back to the editor after toggling
+        if (!mobile) {
+            editor.focus();
+        }
+    });
 
-    $("#show-skipped-button").click(function() {
-      toggleShowSkipped();
+    $("#show-skipped-button").click(function () {
+        toggleShowSkipped();
     })
 
-    $("#end-game-button").click(function() {
+    $("#end-game-button").click(function () {
         endGame();
     });
 
-    $("#user-input").on("change keyup paste", function() {
-        validateProblem()
-    });
+    // $("#vim-checkbox").change(function () {
+    //     const isVimEnabled = $(this).is(":checked");
+    
+    //     if (isVimEnabled) {
+    //         editor.setOption("keyMap", "vim");
+    //         editor.getWrapperElement().classList.add("vim-mode");
+    //     } else {
+    //         editor.setOption("keyMap", "default");
+    //         editor.getWrapperElement().classList.remove("vim-mode");
+    //     }
+    
+    //     if (!mobile) {
+    //         editor.focus();
+    //     }
+    // });
 
     $("#shadow-checkbox").change(_ => {
         $("#shadow-target").toggle();
     });
 
     $("#l-shadow-checkbox").keydown(e => {
-      if (e.which == 13 /* enter */) {
-        $("#shadow-checkbox").prop("checked", !$("#shadow-checkbox").prop("checked"));
-        $("#shadow-target").toggle();
-      }
+        if (e.which == 13 /* enter */) {
+            $("#shadow-checkbox").prop("checked", !$("#shadow-checkbox").prop("checked"));
+            $("#shadow-target").toggle();
+        }
     });
 
     // Leaderboard handlers
-    $("#submit-score").click(function() {
+    $("#submit-score").click(function () {
         const playerName = $("#player-name").val().trim();
         if (playerName.length === 0) {
             alert("Please enter your name");
@@ -402,24 +446,24 @@ $(document).ready(function() {
             alert("Name must be 30 characters or less");
             return;
         }
-        
+
         submitScore(playerName, currentScore);
         $("#score-submission").hide();
     });
-    
-    $("#today-scores, #month-scores, #all-time-scores").click(function() {
+
+    $("#today-scores, #month-scores, #all-time-scores").click(function () {
         const timeRange = $(this).attr('id').replace('-scores', '');
-        
+
         // Update active button
         $(".leaderboard-controls .latex-button").removeClass('active');
         $(this).addClass('active');
-        
+
         loadLeaderboard(timeRange);
     });
-    
-    $("#play-again-button").click(function() {
+
+    $("#play-again-button").click(function () {
         showIntro();
     });
-    
+
     showIntro();
 });

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -387,7 +387,6 @@ $(document).ready(function () {
     
         if (isVimEnabled) {
             editor.setOption("keyMap", "vim");
-            // Add a visual indicator so the user knows they are in a modal editor
             editor.getWrapperElement().classList.add("vim-mode");
         } else {
             editor.setOption("keyMap", "default");
@@ -407,22 +406,6 @@ $(document).ready(function () {
     $("#end-game-button").click(function () {
         endGame();
     });
-
-    // $("#vim-checkbox").change(function () {
-    //     const isVimEnabled = $(this).is(":checked");
-    
-    //     if (isVimEnabled) {
-    //         editor.setOption("keyMap", "vim");
-    //         editor.getWrapperElement().classList.add("vim-mode");
-    //     } else {
-    //         editor.setOption("keyMap", "default");
-    //         editor.getWrapperElement().classList.remove("vim-mode");
-    //     }
-    
-    //     if (!mobile) {
-    //         editor.focus();
-    //     }
-    // });
 
     $("#shadow-checkbox").change(_ => {
         $("#shadow-target").toggle();

--- a/public/assets/style/style.css
+++ b/public/assets/style/style.css
@@ -162,8 +162,9 @@ main {
 	margin-right: auto;
 }
 
-#user-input {
+.latex-source.CodeMirror {
 	height: 100px;
+    border: 2px solid black;
 }
 
 .answer {
@@ -215,13 +216,26 @@ main {
 #toggle-shadow-desc {
 	display: inline;
 	margin-left: 10px;
-	margin-top: auto;
-	margin-bottom: auto;
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
+#toggle-vim-desc {
+	display: inline;
+	margin-left: 10px;
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
+
+#option-container {
+	display: flex;
+	align-items: center;
 }
 
 #options-container {
-	display: flex;
-	align-items: center;
+    display: flex;
+    gap: 20px;
 }
 
 .checkbox {

--- a/public/index.html
+++ b/public/index.html
@@ -23,15 +23,23 @@
 
   <!-- custom css -->
   <link rel="stylesheet" href="assets/style/style.css">
+  <link rel="stylesheet" href="assets/lib/codemirror5/lib/codemirror.css"/>
+  <link rel="stylesheet" href="assets/lib/codemirror5/theme/gruvbox-dark.css">
 
   <!-- js lib -->
   <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
   <script defer src="assets/lib/katex/katex.min.js"></script>
   <script defer src="assets/lib/katex/contrib/auto-render.min.js"></script>
   <script defer src="assets/lib/html2canvas.min.js"></script>
+  <script type="module" src="assets/lib/codemirror5/src/edit/main.js"></script>
   <script src="https://bundle.run/pixelmatch@5.0.2"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore-compat.js"></script>
+  <script type="module"/>
+    import { CodeMirror } from './assets/lib/codemirror5/src/edit/main.js';
+    window.CodeMirror = CodeMirror;
+    </script>
+<script type="module" src="assets/lib/codemirror5/keymap/vim.js"></script>
 
   <!-- custom js -->
   <script src="assets/js/firebase-config.js"></script>
@@ -199,11 +207,18 @@
         <br><br>
 
         <div id="options-container">
+        <div id="option-container">
           <input type="checkbox" class="checkbox" id="shadow-checkbox"></input>
           <label id="l-shadow-checkbox" for="shadow-checkbox" tabindex="0"></label>
           <p id="toggle-shadow-desc">Toggle Shadow</p>
         </div>
+        <div id="option-container">
+            <input type="checkbox" class="checkbox" id="vim-checkbox"></input>
+            <label id="l-vim-checkbox" for="vim-checkbox" tabindex="0"></label>
+            <p id="toggle-vim-desc">Toggle Vim Mode</p>
+          </div>
       </div>
+    </div>
     </div>
   </main>
 </body>


### PR DESCRIPTION
Added Vim mode support for code editing.

This PR added basic vim keymaps that could be activated via a toggle.

## Changes
- Added static dependency `codemirror5` cloned from [this repo](https://code.haverbeke.berlin/codemirror/codemirror5.git) to the `lib` directory
- Added a new checkbox `#vim-checkbox`
- Updated code editor to be a CodeMirror editor instance based on the original `textarea`
- Added event handlers for the vim checkbox

## Implementation Details
- Editor mode is not in vim mode by default