### PR TITLE
Implement bracket pairing and handling for user input

### DIFF
--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -481,6 +481,25 @@ $(document).ready(function() {
                     return;
                 }
             }
+
+            // \begin{ - do not auto-close the brace; let default insert { only
+            if (e.key === '{' && start === end && textBefore.endsWith('\\begin')) {
+                return;
+            }
+
+            // \begin{xxx} -> \begin{xxx}\end{xxx} with cursor between
+            if (e.key === '}' && start === end) {
+                const beginMatch = textBefore.match(/\\begin\{([^}]+)$/);
+                if (beginMatch) {
+                    const envName = beginMatch[1];
+                    e.preventDefault();
+                    textarea.value = textBefore + '}\\end{' + envName + '}' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+            }
+
         }
 
         const open = e.key;

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -403,6 +403,86 @@ $(document).ready(function() {
             return;
         }
 
+        // Handle special \left sequences and multi-char delimiter patterns
+        {
+            const textarea = this;
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            const val = textarea.value;
+            const textBefore = val.substring(0, start);
+            const textAfter = val.substring(end);
+
+            // \left| -> |\right|
+            if (e.key === '|' && start === end && textBefore.endsWith('\\left')) {
+                e.preventDefault();
+                textarea.value = textBefore + '|\\right|' + textAfter;
+                textarea.selectionStart = textarea.selectionEnd = start + 1;
+                validateProblem();
+                return;
+            }
+
+            // \left< -> <\right>
+            if (e.key === '<' && start === end && textBefore.endsWith('\\left')) {
+                e.preventDefault();
+                textarea.value = textBefore + '<\\right>' + textAfter;
+                textarea.selectionStart = textarea.selectionEnd = start + 1;
+                validateProblem();
+                return;
+            }
+
+            // \lang -> \lang\rang (cursor between); \langl+e with \rang after -> \langle\rangle
+            if (e.key === 'g' && start === end && textBefore.endsWith('\\lan')) {
+                e.preventDefault();
+                textarea.value = textBefore + 'g\\rang' + textAfter;
+                textarea.selectionStart = textarea.selectionEnd = start + 1;
+                validateProblem();
+                return;
+            }
+            if (e.key === 'e' && start === end && textBefore.endsWith('\\langl') && textAfter.startsWith('\\rang')) {
+                e.preventDefault();
+                textarea.value = textBefore + 'e\\rangle' + textAfter.substring('\\rang'.length);
+                textarea.selectionStart = textarea.selectionEnd = start + 1;
+                validateProblem();
+                return;
+            }
+
+            // \lfloor / \left\lfloor -> \rfloor / \right\rfloor
+            if (e.key === 'r' && start === end) {
+                if (textBefore.endsWith('\\left\\lfloo')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 'r\\right\\rfloor' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+                if (textBefore.endsWith('\\lfloo')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 'r\\rfloor' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+            }
+
+            // \lceil / \left\lceil -> \rceil / \right\rceil
+            if (e.key === 'l' && start === end) {
+                if (textBefore.endsWith('\\left\\lcei')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 'l\\right\\rceil' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+                if (textBefore.endsWith('\\lcei')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 'l\\rceil' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+            }
+        }
+
         const open = e.key;
         if (!(open in bracketPairs) && !closeBrackets.has(e.key)) return;
 

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -403,6 +403,28 @@ $(document).ready(function() {
             return;
         }
 
+        // Tab: skip past the next } or \end{xxx}
+        if (e.key === 'Tab') {
+            e.preventDefault();
+            const textarea = this;
+            const start = textarea.selectionStart;
+            if (start === textarea.selectionEnd) {
+                const val = textarea.value;
+                const textAfter = val.substring(start);
+                const endMatch = textAfter.match(/^\\end\{[^}]*\}/);
+                if (endMatch) {
+                    textarea.selectionStart = textarea.selectionEnd = start + endMatch[0].length;
+                    return;
+                }
+                const braceIdx = textAfter.indexOf('}');
+                if (braceIdx !== -1) {
+                    textarea.selectionStart = textarea.selectionEnd = start + braceIdx + 1;
+                    return;
+                }
+            }
+            return;
+        }
+
         // Handle special \left sequences and multi-char delimiter patterns
         {
             const textarea = this;
@@ -412,6 +434,15 @@ $(document).ready(function() {
             const textBefore = val.substring(0, start);
             const textAfter = val.substring(end);
 
+            // \left\| -> \left\|\right\|
+            if (e.key === '|' && start === end && textBefore.endsWith('\\left\\')) {
+                e.preventDefault();
+                textarea.value = textBefore + '|\\right\\|' + textAfter;
+                textarea.selectionStart = textarea.selectionEnd = start + 1;
+                validateProblem();
+                return;
+            }
+
             // \left| -> |\right|
             if (e.key === '|' && start === end && textBefore.endsWith('\\left')) {
                 e.preventDefault();
@@ -419,6 +450,18 @@ $(document).ready(function() {
                 textarea.selectionStart = textarea.selectionEnd = start + 1;
                 validateProblem();
                 return;
+            }
+
+            // \| alone -> \|\| (double bar norm)
+            if (e.key === '|' && start === end && textBefore.endsWith('\\')) {
+                const charBeforeSlash = textBefore[textBefore.length - 2];
+                if (charBeforeSlash === undefined || !/[a-zA-Z]/.test(charBeforeSlash)) {
+                    e.preventDefault();
+                    textarea.value = textBefore + '|\\|' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
             }
 
             // \left< -> <\right>
@@ -440,7 +483,9 @@ $(document).ready(function() {
             }
             if (e.key === 'e' && start === end && textBefore.endsWith('\\langl') && textAfter.startsWith('\\rang')) {
                 e.preventDefault();
-                textarea.value = textBefore + 'e\\rangle' + textAfter.substring('\\rang'.length);
+                const isLeft = textBefore.endsWith('\\left\\langl');
+                const closeStr = isLeft ? '\\right\\rangle' : '\\rangle';
+                textarea.value = textBefore + 'e' + closeStr + textAfter.substring('\\rang'.length);
                 textarea.selectionStart = textarea.selectionEnd = start + 1;
                 validateProblem();
                 return;
@@ -476,6 +521,39 @@ $(document).ready(function() {
                 if (textBefore.endsWith('\\lcei')) {
                     e.preventDefault();
                     textarea.value = textBefore + 'l\\rceil' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+            }
+
+            // \lvert / \left\lvert -> \rvert / \right\rvert
+            // \lVert / \left\lVert -> \rVert / \right\rVert
+            if (e.key === 't' && start === end) {
+                if (textBefore.endsWith('\\left\\lver')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 't\\right\\rvert' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+                if (textBefore.endsWith('\\lver')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 't\\rvert' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+                if (textBefore.endsWith('\\left\\lVer')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 't\\right\\rVert' + textAfter;
+                    textarea.selectionStart = textarea.selectionEnd = start + 1;
+                    validateProblem();
+                    return;
+                }
+                if (textBefore.endsWith('\\lVer')) {
+                    e.preventDefault();
+                    textarea.value = textBefore + 't\\rVert' + textAfter;
                     textarea.selectionStart = textarea.selectionEnd = start + 1;
                     validateProblem();
                     return;

--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -380,6 +380,76 @@ $(document).ready(function() {
         validateProblem()
     });
 
+    const bracketPairs = { '(': ')', '[': ']', '{': '}' };
+    const closeBrackets = new Set(Object.values(bracketPairs));
+    $("#user-input").on("keydown", function(e) {
+        // Backspace: delete matching close bracket if cursor is between a pair
+        if (e.key === 'Backspace') {
+            const textarea = this;
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            if (start === end && start > 0) {
+                const val = textarea.value;
+                const charBefore = val[start - 1];
+                const charAfter = val[start];
+                if (charBefore in bracketPairs && bracketPairs[charBefore] === charAfter) {
+                    e.preventDefault();
+                    textarea.value = val.substring(0, start - 1) + val.substring(start + 1);
+                    textarea.selectionStart = start - 1;
+                    textarea.selectionEnd = start - 1;
+                    validateProblem();
+                }
+            }
+            return;
+        }
+
+        const open = e.key;
+        if (!(open in bracketPairs) && !closeBrackets.has(e.key)) return;
+
+        // Close bracket: skip over it if it's already the next character
+        if (closeBrackets.has(e.key)) {
+            const textarea = this;
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            if (start === end && textarea.value[start] === e.key) {
+                e.preventDefault();
+                textarea.selectionStart = start + 1;
+                textarea.selectionEnd = start + 1;
+            }
+            return;
+        }
+
+        if (!(open in bracketPairs)) return;
+        const close = bracketPairs[open];
+        const textarea = this;
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const val = textarea.value;
+        const textBefore = val.substring(0, start);
+        const precededByLeftBackslash = open === '{' && textBefore.endsWith('\\left\\');                    // "\left\}" case
+        const precededByLeft = !precededByLeftBackslash && textBefore.endsWith('\\left');                   // "\left" case but not "\left\"
+        const precededByBackslash = open === '{' && !precededByLeftBackslash && textBefore.endsWith('\\');  // "\" case for "{" but not "\left\{"
+        const closeStr = precededByLeftBackslash ? '\\right\\}' :       // "\left\}" -> "\right\}"
+                         precededByLeft         ? '\\right' + close :   // "\left?" -> "\right?"
+                         precededByBackslash    ? '\\}' :               // "\{" -> "\}"
+                                                  close;                // normal case: "(" -> ")", etc.
+        e.preventDefault();
+        if (start !== end) {
+            // Wrap the selection
+            const selected = val.substring(start, end);
+            textarea.value = val.substring(0, start) + open + selected + closeStr + val.substring(end);
+            textarea.selectionStart = start + 1;
+            textarea.selectionEnd = end + 1;
+        } else {
+            // Insert pair and place cursor between them
+            textarea.value = val.substring(0, start) + open + closeStr + val.substring(end);
+            textarea.selectionStart = start + 1;
+            textarea.selectionEnd = start + 1;
+        }
+
+        validateProblem();
+    });
+
     $("#shadow-checkbox").change(_ => {
         $("#shadow-target").toggle();
     });


### PR DESCRIPTION
This pull request implements auto-completion features for LaTeX input in the game.
All auto-completions apply to the `#user-input` textarea in the game.
Below is a summary of the implemented features, with examples of the auto-completion behavior.

## Bracket pair auto-close

| Typed | Result | Cursor |
|---|---|---|
| `(` | `()` | between |
| `[` | `[]` | between |
| `{` | `{}` | between |

- **Selection wrap**: with text selected, typing `(`, `[`, or `{` wraps the selection in the pair.
- **Skip-over**: typing `)`, `]`, or `}` when that character is already immediately after the cursor moves the cursor past it instead of inserting a duplicate.
- **Paired backspace**: pressing Backspace between a matched pair deletes both brackets.

---

## `\left`/`\right` delimiter pairs

| Typed | Result | Cursor |
|---|---|---|
| `\left(` | `\left(\right)` | between |
| `\left[` | `\left[\right]` | between |
| `\left{` | `\left{\right}` | between |
| `\left\{` | `\left\{\right\}` | between |
| `\left\|` | `\left\|\right\|` | between |
| `\left\\|` | `\left\\|\right\\|` | between |
| `\left<` | `\left<\right>` | between |

---

## Escaped bracket pairs

| Typed | Result | Cursor |
|---|---|---|
| `\{` | `\{\}` | between |
| `\\|` | `\\|\\|` | between |

> `|` alone does not trigger auto-completion.

---

## Named delimiter pairs

| Typed | Result | Cursor |
|---|---|---|
| `\langle` | `\langle\rangle` | between |
| `\left\langle` | `\left\langle\right\rangle` | between |
| `\lfloor` | `\lfloor\rfloor` | between |
| `\left\lfloor` | `\left\lfloor\right\rfloor` | between |
| `\lceil` | `\lceil\rceil` | between |
| `\left\lceil` | `\left\lceil\right\rceil` | between |
| `\lvert` | `\lvert\rvert` | between |
| `\left\lvert` | `\left\lvert\right\rvert` | between |
| `\lVert` | `\lVert\rVert` | between |
| `\left\lVert` | `\left\lVert\right\rVert` | between |

> `\langle` completion is incremental: `\lang` first inserts `\lang\rang`, then completing to `\langle` automatically upgrades the closing tag to `\rangle` (or `\right\rangle` when preceded by `\left\`).

---

## Environment auto-close

| Typed | Result | Cursor |
|---|---|---|
| `\begin{align}` | `\begin{align}\end{align}` | between |

- `{` after `\begin` is **not** auto-closed — the user types the environment name freely and closes with `}`.
- Typing `}` to close `\begin{envname` triggers the completion: inserts `}\end{envname}` and places the cursor between the `\begin` and `\end` blocks.

---

## Navigation

| Key | Action |
|---|---|
| **Tab** | Jumps cursor past the next `}` in the text. If the cursor is immediately before `\end{...}`, jumps past the entire `\end{envname}` tag instead. |
